### PR TITLE
fix: isolate localhost testing runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "api": "node server.mjs",
-    "dev:all": "concurrently \"npm run api\" \"npm run dev -- --host 127.0.0.1 --port 5173\"",
+    "dev:all": "concurrently \"npm run api\" \"npm run dev -- --host 127.0.0.1 --port 5273\"",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/server.mjs
+++ b/server.mjs
@@ -4,8 +4,8 @@ import fs from 'fs/promises'
 import path from 'path'
 
 const app = express()
-const PORT = 4173
-const DATA_PATH = path.resolve(process.cwd(), '../kanban-data.json')
+const PORT = Number(process.env.PORT || 4273)
+const DATA_PATH = path.resolve(process.cwd(), process.env.KANBAN_DATA_PATH || './kanban-data.local.json')
 
 const emptyColumns = {
   todo: [],


### PR DESCRIPTION
Prevents conflict with existing Kanban by using separate default ports and isolated local data file.\n\nChanges:\n- API default port -> 4273 (env override via PORT)\n- UI dev port -> 5273\n- Data file -> ./kanban-data.local.json (env override via KANBAN_DATA_PATH)