### PR TITLE
chore: ignore local kanban-data file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+kanban-data.local.json


### PR DESCRIPTION
Prevents accidental commits of local test data () when using GitHub Desktop or local dev runs.